### PR TITLE
Update deprecated frontend dependencies

### DIFF
--- a/app/frontend/react-app/package.json
+++ b/app/frontend/react-app/package.json
@@ -4,20 +4,20 @@
   "private": true,
   "proxy": "http://localhost:8501",
   "dependencies": {
-    "@emotion/react": "^11.11.0",
+    "@emotion/react": "^11.11.3",
     "@emotion/styled": "^11.11.0",
-    "@mui/icons-material": "^5.11.16",
-    "@mui/material": "^5.13.0",
-    "@types/node": "^16.18.31",
-    "@types/react": "^18.2.6",
-    "@types/react-dom": "^18.2.4",
-    "axios": "^1.4.0",
-    "plotly.js-dist-min": "^2.23.2",
+    "@mui/icons-material": "^5.15.10",
+    "@mui/material": "^5.15.10",
+    "@types/node": "^20.11.19",
+    "@types/react": "^18.2.57",
+    "@types/react-dom": "^18.2.19",
+    "axios": "^1.6.7",
+    "plotly.js-dist-min": "^2.29.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.11.1",
-    "recharts": "^2.6.2",
-    "typescript": "^4.9.5"
+    "react-router-dom": "^6.22.1",
+    "recharts": "^2.12.0",
+    "typescript": "^5.3.3"
   },
   "scripts": {
     "start": "react-scripts start",
@@ -45,12 +45,28 @@
     ]
   },
   "devDependencies": {
-    "@testing-library/jest-dom": "^5.16.5",
-    "@testing-library/react": "^13.4.0",
-    "@testing-library/user-event": "^13.5.0",
-    "@types/jest": "^27.5.2",
-    "@types/plotly.js-dist-min": "^2.3.1",
+    "@babel/plugin-transform-class-properties": "^7.23.3",
+    "@babel/plugin-transform-nullish-coalescing-operator": "^7.23.4",
+    "@babel/plugin-transform-numeric-separator": "^7.23.4",
+    "@babel/plugin-transform-optional-chaining": "^7.23.4",
+    "@babel/plugin-transform-private-methods": "^7.23.3",
+    "@babel/plugin-transform-private-property-in-object": "^7.23.4",
+    "@eslint/config-array": "^2.1.0",
+    "@eslint/object-schema": "^2.0.1",
+    "@rollup/plugin-terser": "^0.4.4",
+    "@testing-library/jest-dom": "^6.4.2",
+    "@testing-library/react": "^14.2.1",
+    "@testing-library/user-event": "^14.5.2",
+    "@types/jest": "^29.5.12",
+    "@types/plotly.js-dist-min": "^2.3.4",
+    "eslint": "^8.57.0",
     "react-scripts": "5.0.1",
+    "rimraf": "^5.0.5",
     "source-map-explorer": "^2.5.3"
+  },
+  "overrides": {
+    "workbox-cacheable-response": "^7.0.0",
+    "@svgr/webpack": "^8.1.0",
+    "svgo": "^3.2.0"
   }
-} 
+}


### PR DESCRIPTION
This PR addresses several deprecated package warnings in the frontend React application.

Changes made:
1. Updated all core dependencies to their latest stable versions
2. Replaced deprecated Babel plugins with their modern equivalents:
   - @babel/plugin-proposal-* → @babel/plugin-transform-*
3. Updated ESLint related packages:
   - @humanwhocodes/config-array → @eslint/config-array
   - @humanwhocodes/object-schema → @eslint/object-schema
4. Added overrides for problematic dependencies:
   - Updated workbox-cacheable-response to v7
   - Updated svgo to v3
   - Updated @svgr/webpack to v8

These changes should resolve all the deprecation warnings while maintaining compatibility.